### PR TITLE
Add symlink to README.md

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,1 @@
+README.md


### PR DESCRIPTION
Stops the following error when running python setup.py install:

IOError: [Errno 2] No such file or directory: 'README
